### PR TITLE
add audience requirement to jwt decoding

### DIFF
--- a/passageidentity/helper.py
+++ b/passageidentity/helper.py
@@ -61,9 +61,10 @@ def fetchPublicKey(app_id):
 
     try:
         public_key = r.json()["app"]["rsa_public_key"]
+        origin = r.json()["app"]["auth_origin"]
         keyBytes = b64decode(public_key)
         pubKey = load_pem_public_key(keyBytes, default_backend())
-        return pubKey
+        return pubKey, origin
     except Exception as e:
         raise PassageError("Could not fetch public key for app id " + app_id)
 

--- a/passageidentity/passage.py
+++ b/passageidentity/passage.py
@@ -68,10 +68,11 @@ class Passage():
 
         # if the pubkey exists in the cache, use that to avoid making requests
         if app_id in PUBKEY_CACHE.keys():
-            self.passage_pubkey: str = PUBKEY_CACHE[app_id]
+            self.passage_pubkey: str = PUBKEY_CACHE[app_id]["public_key"]
+            self.auth_origin: str = PUBKEY_CACHE[app_id]["auth_origin"]
         else:
-            self.passage_pubkey: str = fetchPublicKey(app_id)
-            PUBKEY_CACHE[app_id] = self.passage_pubkey
+            self.passage_pubkey, self.auth_origin = fetchPublicKey(app_id)
+            PUBKEY_CACHE[app_id] = {"public_key": self.passage_pubkey, "auth_origin": self.auth_origin}
     
 
     """
@@ -87,7 +88,7 @@ class Passage():
 
         # load and parse the JWT
         try:
-            claims = jwt.decode(token, self.passage_pubkey, algorithms=["RS256"])
+            claims = jwt.decode(token, self.passage_pubkey, audience=self.auth_origin, algorithms=["RS256"])
             return claims["sub"]
         except Exception as e:
             raise PassageError("JWT is not valid: " + str(e))
@@ -101,7 +102,7 @@ class Passage():
     def authenticateJWT(self, token:str) -> Union[str, PassageError]:
         # load and parse the JWT
         try:
-            claims = jwt.decode(token, self.passage_pubkey, algorithms=["RS256"])
+            claims = jwt.decode(token, self.passage_pubkey, audience=self.auth_origin, algorithms=["RS256"])
             return claims["sub"]
         except Exception as e:
             raise PassageError("JWT is not valid: " + str(e)) 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="passage-identity",
-    version="1.2.2",
+    version="1.2.3",
     author="Passage Identity, Inc",
     author_email="support@passage.id",
     description="Python library to help manage your Passage application and users",


### PR DESCRIPTION
Per this doc, if there is an aud claim, you have to pass the audience parameter to decode. 
https://github.com/jpadilla/pyjwt/blob/master/docs/usage.rst#audience-claim-aud

I'm current caching the auth origin with the public key, but maybe we need ot change that?