### PR TITLE
Fix bug where Python version below 3.8 failed

### DIFF
--- a/passageidentity/passage.py
+++ b/passageidentity/passage.py
@@ -6,7 +6,8 @@ import sys
 if sys.version_info >= (3, 8):
     from typing import TypedDict, Union
 else:
-    from typing_extensions import TypeDict, Union
+    from typing_extensions import TypedDict
+    from typing import Union
 
 from requests.sessions import Request
 from passageidentity.helper import fetchApp, getAuthTokenFromRequest


### PR DESCRIPTION
Changed import statements for Python versions below 3.8. Now any version below 3.8 will import TypedDict from typing_extensions module and Union from typing module. Tested with Python 3.7.9 and 3.6.0 - both work.