### PR TITLE
Fix bug where Python version below 3.8 failed

### DIFF
--- a/passageidentity/passage.py
+++ b/passageidentity/passage.py
@@ -72,6 +72,7 @@ class Passage():
     class PassageDeviceType(TypedDict):
         created_at: str
         updated_at: str
+        last_login_at: str
         id: str
         cred_id: str
         friendly_name: str
@@ -413,6 +414,10 @@ class PassageDevice:
             self.updated_at = datetime.strptime(time_to_milliseconds(fields["updated_at"]),"%Y-%m-%dT%H:%M:%S.%fZ")
         except:
             self.updated_at = datetime.strptime(fields["updated_at"],"%Y-%m-%dT%H:%M:%SZ")
+        try:
+            self.last_login_at = datetime.strptime(time_to_milliseconds(fields["last_login_at"]),"%Y-%m-%dT%H:%M:%S.%fZ")
+        except:
+            self.last_login_at = datetime.strptime(fields["last_login_at"],"%Y-%m-%dT%H:%M:%SZ")
         self.friendly_name = fields["friendly_name"]
         self.usage_count = fields["usage_count"]
 

--- a/passageidentity/passage.py
+++ b/passageidentity/passage.py
@@ -6,7 +6,8 @@ import sys
 if sys.version_info >= (3, 8):
     from typing import TypedDict, Union
 else:
-    from typing_extensions import TypeDict, Union
+    from typing_extensions import TypedDict
+    from typing import Union
 
 from requests.sessions import Request
 from passageidentity.helper import fetchApp, getAuthTokenFromRequest

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="passage-identity",
-    version="1.3.2",
+    version="2.0.1",
     author="Passage Identity, Inc",
     author_email="support@passage.id",
     description="Python library to help manage your Passage application and users",


### PR DESCRIPTION
Changed import statements for Python versions below 3.8. Now any version below 3.8 will import TypedDict from typing_extensions module and Union from typing module. Tested with Python 3.7.9 and 3.6.0 - both work.