### PR TITLE
PSG-956 - propogate API errors up to PassageError class

### DIFF
--- a/passageidentity/errors.py
+++ b/passageidentity/errors.py
@@ -2,7 +2,12 @@
 Error class for Passage errors
 """
 class PassageError(Exception):
-    def __init__(self, message="Error in Passage"):
+    def __init__(self, message, status_code:int=None, status_text:str=None, body:dict=None):
         self.message = message
-        super().__init__(self.message)
+        self.status_code = status_code
+        self.status_text = status_text
+        if body != None:
+            self.error = body["error"]
+        else:
+            self.error = None
 

--- a/tests/errors_test.py
+++ b/tests/errors_test.py
@@ -1,0 +1,17 @@
+from ast import Pass
+from passageidentity import PassageError
+import pytest
+
+def testErrorWithAllValues():
+    error = PassageError("some message", 400, "Bad Request", {"error": "some error"})
+    assert error.message == "some message"
+    assert error.status_code == 400
+    assert error.status_text == "Bad Request"
+    assert error.error == "some error"
+    
+def testErrorWithOnlyMessage():
+    error = PassageError("some message")
+    assert error.message == "some message"
+    assert error.status_code == None 
+    assert error.status_text == None
+    assert error.error == None


### PR DESCRIPTION
PassageError class now containes these fields:
`message` -> descriptive information regarding the error from the sdk
`status_code` (optional) -> api status code from an API request to the passage backend
`status_text` (optional) -> api status text from an API request to the passage backend
`error` (optional) -> api descriptive error from an API request to the passage backend