### PR TITLE
Improve error handling

### DIFF
--- a/passageidentity/helper.py
+++ b/passageidentity/helper.py
@@ -21,7 +21,7 @@ def extractToken(authHeader):
     try:
         return match.group(1)
     except (AttributeError, IndexError):
-        return None
+        raise PassageError("No Passage authorization header.")
 
 """
 Helper funtion to get the auth token from a request.
@@ -35,7 +35,7 @@ def getAuthTokenFromRequest(request, auth_strategy):
         try:
             return match.group(1)
         except (AttributeError, IndexError):
-            return None
+            raise PassageError("No Passage authorization header.")
     else:
         try:
             cookies = request.COOKIES

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="passage-identity",
-    version="2.1.3",
+    version="2.1.4",
     author="Passage Identity, Inc",
     author_email="support@passage.id",
     description="Python library to help manage your Passage application and users",


### PR DESCRIPTION
## Description
Currently, nothing is returned if the authorization errors are missing. This PR throws errors when the correct authorization header is missing.

Previous deploy failed. Including the change to increase the version number.