### PR TITLE
feat: add support for OIDC tokens

### DIFF
--- a/passageidentity/passage.py
+++ b/passageidentity/passage.py
@@ -64,6 +64,19 @@ class Passage():
         return jwkItems
 
     """
+    Fetch whether the app is hosted
+    """
+    def __fetchHosted(self):
+        r = requests.get(f"https://api.passage.id/v1/apps/{self.app_id}", api_key=self.passage_apikey)
+
+        if r.status_code != 200:
+            raise PassageError("Could not fetch app info for app id " + self.app_id, r.status_code, r.reason, r.json())
+
+        hosted = r.json()["app"]["hosted"]
+
+        return hosted
+
+    """
     This function will verify the JWT and return the user ID for the authenticated user, or throw
     a PassageError. Takes the place of the deprecated authenticateRequest() function.
     """
@@ -73,13 +86,7 @@ class Passage():
     def __refreshAuthCache(self):
         self.auth_origin = fetchApp(self.app_id)["auth_origin"]
         self.jwks = self.__fetchJWKS()
-
-        r = requests.get(f"https://api.passage.id/v1/apps/{self.app_id}", api_key=self.passage_apikey)
-
-        if r.status_code != 200:
-            raise PassageError("Could not fetch app info for app id " + self.app_id, r.status_code, r.reason, r.json())
-
-        hosted = r.json()["app"]["hosted"]
+        hosted = self.__fetchHosted()
 
         AUTH_CACHE[self.app_id] = {"jwks": self.jwks, "auth_origin": self.auth_origin, "hosted": hosted}
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="passage-identity",
-    version="2.4.0",
+    version="2.5.0",
     author="Passage Identity, Inc",
     author_email="support@passage.id",
     description="Python library to help manage your Passage application and users",


### PR DESCRIPTION
### Overview of Changes in this PR

-   support OIDC-compliant tokens from hosted apps when authenticating JWTs

### How to Test

-   Create a hosted app in Passage Console.
-   Get an OIDC-compliant token with the "Try it out" flow in Passage Console.
-   Verify the token with `authenticateJWT`. The user's ID should be returned successfully.