### PR TITLE
PSG-4621 unused dependencies

### DIFF
--- a/passageidentity/helper.py
+++ b/passageidentity/helper.py
@@ -1,7 +1,6 @@
 import os
 import re
 from base64 import b64decode
-from django.core.handlers.wsgi import WSGIRequest
 
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
 from cryptography.hazmat.backends import default_backend

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,6 @@ setuptools.setup(
     install_requires=[
         'aenum',
         'cryptography',
-        'django < 5', 
-        'Flask', 
         'importlib-metadata >= 1.0 ; python_version < "3.12"',
         'pydantic',
         'pyjwt',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setuptools.setup(
     install_requires=[
         'aenum',
         'cryptography',
-        'Flask',
         'importlib-metadata >= 1.0 ; python_version < "3.12"',
         'pydantic',
         'pyjwt',

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setuptools.setup(
     install_requires=[
         'aenum',
         'cryptography',
+        'Flask',
         'importlib-metadata >= 1.0 ; python_version < "3.12"',
         'pydantic',
         'pyjwt',

--- a/tests/authenticate_test.py
+++ b/tests/authenticate_test.py
@@ -4,8 +4,10 @@ import pytest
 import os
 import random
 import string
+from flask import Flask, request
 from dotenv import load_dotenv
 
+app = Flask(__name__)
 
 load_dotenv()
 PASSAGE_USER_ID = os.environ.get("PASSAGE_USER_ID")

--- a/tests/authenticate_test.py
+++ b/tests/authenticate_test.py
@@ -4,10 +4,10 @@ import pytest
 import os
 import random
 import string
-from flask import Flask, request
+from flask import request
 from dotenv import load_dotenv
+from werkzeug.http import dump_cookie
 
-app = Flask(__name__)
 
 load_dotenv()
 PASSAGE_USER_ID = os.environ.get("PASSAGE_USER_ID")

--- a/tests/authenticate_test.py
+++ b/tests/authenticate_test.py
@@ -5,8 +5,6 @@ import os
 import random
 import string
 from dotenv import load_dotenv
-from werkzeug.http import dump_cookie
-
 
 load_dotenv()
 PASSAGE_USER_ID = os.environ.get("PASSAGE_USER_ID")

--- a/tests/authenticate_test.py
+++ b/tests/authenticate_test.py
@@ -4,7 +4,6 @@ import pytest
 import os
 import random
 import string
-from flask import request
 from dotenv import load_dotenv
 from werkzeug.http import dump_cookie
 
@@ -20,20 +19,6 @@ def randomEmail():
 
 def randomPhone():
     return  "+1512" + ''.join(random.choice('23456789') for _ in range(7))
-
-def testFlaskValidTokenInHeader():
-    psg = Passage(PASSAGE_APP_ID, auth_strategy=Passage.HEADER_AUTH)
-    # flask request context
-    with app.test_request_context("thisisaurl.com",headers={'Authorization':f'Bearer {PASSAGE_AUTH_TOKEN}'}):
-        user = psg.authenticateRequest(request)
-        assert user == PASSAGE_USER_ID
-
-def testFlaskInvalidTokenInHeader():
-    psg = Passage(PASSAGE_APP_ID, auth_strategy=Passage.HEADER_AUTH)
-    # flask request context
-    with app.test_request_context("thisisaurl.com",headers={'Authorization':f'Bearer invalid_token'}):
-        with pytest.raises(PassageError):
-            psg.authenticateRequest(request)
 
 def testValidJWT():
     psg = Passage(PASSAGE_APP_ID, auth_strategy=Passage.HEADER_AUTH)
@@ -53,22 +38,6 @@ def testValidateJWT():
 def testFetchJWKS():
     psg = Passage(PASSAGE_APP_ID, auth_strategy=Passage.HEADER_AUTH)
     assert len(psg.jwks) > 0
-
-def testFlaskValidTokenInCookie():
-    psg = Passage(PASSAGE_APP_ID)
-    # flask request context
-    cookie = dump_cookie('psg_auth_token', PASSAGE_AUTH_TOKEN)
-    with app.test_request_context("thisisaurl.com",environ_base={'HTTP_COOKIE':cookie}):
-        user = psg.authenticateRequest(request)
-        assert user == PASSAGE_USER_ID
-
-def testFlaskInvalidTokenInCookie():
-    psg = Passage(PASSAGE_APP_ID)
-    # flask request context
-    cookie = dump_cookie('psg_auth_token', "invalid_token")
-    with app.test_request_context("thisisaurl.com",environ_base={'HTTP_COOKIE':cookie}):
-        with pytest.raises(PassageError):
-            psg.authenticateRequest(request)
 
 def testGetApp():
     psg = Passage(PASSAGE_APP_ID, PASSAGE_API_KEY)

--- a/tests/authenticate_test.py
+++ b/tests/authenticate_test.py
@@ -4,11 +4,8 @@ import pytest
 import os
 import random
 import string
-from flask import Flask, request
 from dotenv import load_dotenv
-from werkzeug.http import dump_cookie
 
-app = Flask(__name__)
 
 load_dotenv()
 PASSAGE_USER_ID = os.environ.get("PASSAGE_USER_ID")


### PR DESCRIPTION
`MarkupSafe` has just been upgraded and is forcing builds to fail. `django` and `flask` are the libraries that have `markupSafe` as a dependency. Removing them should fix the problem.

This package no longer requires django or flask since it is framework agnostic. The removal should significantly reduce the overall package size.