### PR TITLE
ci: adds release as ci

### DIFF
--- a/.github/workflows/release-as.yml
+++ b/.github/workflows/release-as.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Get latest tag
         id: latest-tag
         run: echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
@@ -29,9 +31,9 @@ jobs:
           git commit --allow-empty -m "chore: release ${{ github.event.inputs.version }}" -m "Release-As: ${{ github.event.inputs.version }}"
           git push origin release-as-v${{ github.event.inputs.version }}
           gh pr create --title "chore: Release as v${{ github.event.inputs.version }}" --body "Release as v${{ github.event.inputs.version }}" --base main
-          gh pr merge --squash --delete-branch
+          gh pr merge --squash --delete-branch --admin
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BE_SDK_PAT }}
   call-release-workflow:
     needs: release-as
     uses: ./.github/workflows/release.yml

--- a/.github/workflows/release-as.yml
+++ b/.github/workflows/release-as.yml
@@ -1,0 +1,38 @@
+name: Release As
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Major.Minor.Patch'
+        required: true
+
+jobs:
+  release-as:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get latest tag
+        id: latest-tag
+        run: echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+      - uses: jackbilestech/semver-compare@1.0.4
+        with:
+          head: ${{ inputs.version }}
+          base: ${{ steps.latest-tag.outputs.tag }}
+          operator: '>'
+      # https://github.com/googleapis/release-please?tab=readme-ov-file#how-do-i-change-the-version-number
+      - name: Release as 
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git switch -c release-as-v${{ github.event.inputs.version }}
+          git commit --allow-empty -m "chore: release ${{ github.event.inputs.version }}" -m "Release-As: ${{ github.event.inputs.version }}"
+          git push origin release-as-v${{ github.event.inputs.version }}
+          gh pr create --title "chore: Release as v${{ github.event.inputs.version }}" --body "Release as v${{ github.event.inputs.version }}" --base main
+          gh pr merge --squash --delete-branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  call-release-workflow:
+    needs: release-as
+    uses: ./.github/workflows/release.yml
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   workflow_dispatch:
+  workflow_call:
   push:
     branches:
       - main


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

This is an extension of #108, adding a "release as" workflow to specify a version number to release as instead of the automatically parsed one from release-please

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
