### PR TITLE
chore: PassageError now correctly parses ApiException's deserialized data and raw body

### DIFF
--- a/passageidentity/errors.py
+++ b/passageidentity/errors.py
@@ -39,8 +39,13 @@ class PassageError(Exception):
     @classmethod
     def from_response_error(cls, response_error: ApiException, message: str | None = None) -> PassageError:
         """Initialize the error with a response body and optional message."""
-        error_code = response_error.body["code"] if response_error.body else None
-        error_msg = response_error.body["error"] if response_error.body else None
-        msg = ": ".join(filter(None, [message, error_msg]))
+        if response_error.data is not None:
+            data_dict = response_error.data.to_dict()
+            error_code = data_dict.get("code")
+            error_msg = data_dict.get("error")
+            msg = ": ".join(filter(None, [message, error_msg]))
+        else:
+            error_code = None
+            msg = str(response_error.body)
 
         return cls(message=msg, status_code=response_error.status, error_code=error_code)

--- a/tests/errors_test.py
+++ b/tests/errors_test.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 from passageidentity import PassageError
 from passageidentity.openapi_client.exceptions import ApiException
+from passageidentity.openapi_client.models.model400_error import Model400Error
 
 
 class MockApiException(ApiException):
-    def __init__(self, status: int, body: dict) -> None:
+    def __init__(self, status: int, data: Model400Error | None, body: str | None = None) -> None:
         self.status = status
+        self.data = data
         self.body = body
 
 
@@ -29,13 +33,13 @@ def test_error_with_only_message() -> None:
 def test_from_response_error() -> None:
     response_error = MockApiException(
         status=400,
-        body={"error": "some error", "code": "some_error_code"},
+        data=Model400Error(code="invalid_request", error="some error"),
     )
 
     error = PassageError.from_response_error(response_error, "some message")
     assert error.message == "some message: some error"
     assert error.status_code == 400
-    assert error.error_code == "some_error_code"
+    assert error.error_code == "invalid_request"
     assert error.status_text is None
     assert error.error is None
 
@@ -43,12 +47,27 @@ def test_from_response_error() -> None:
 def test_from_response_error_without_message() -> None:
     response_error = MockApiException(
         status=400,
-        body={"error": "some error", "code": "some_error_code"},
+        data=Model400Error(code="invalid_request", error="some error"),
     )
 
     error = PassageError.from_response_error(response_error)
     assert error.message == "some error"
     assert error.status_code == 400
-    assert error.error_code == "some_error_code"
+    assert error.error_code == "invalid_request"
+    assert error.status_text is None
+    assert error.error is None
+
+
+def test_from_response_error_without_data() -> None:
+    response_error = MockApiException(
+        status=400,
+        data=None,
+        body="some error",
+    )
+
+    error = PassageError.from_response_error(response_error)
+    assert error.message == "some error"
+    assert error.status_code == 400
+    assert error.error_code is None
     assert error.status_text is None
     assert error.error is None


### PR DESCRIPTION


<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes issue where `PassageError` was parsing the wrong error field from `ApiResponse`
- Parses `data` if the error came from our OpenAPI schema
- Parses `body` if the error came was not from our OpenAPI schema
- title is `chore` so this doesn't show up in the release notes since this is a bug fix for a feat that will already be in the notes

## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
