### PR TITLE
feat: make magic link parameter classes kwargs only

### DIFF
--- a/passageidentity/models/magic_link_args.py
+++ b/passageidentity/models/magic_link_args.py
@@ -18,11 +18,23 @@ class MagicLinkWithEmailArgs(MagicLinkArgsBase):
 
     email: str
 
+    def __init__(self, *, email: str, link_type: MagicLinkType, send: bool) -> None:
+        """Initialize the MagicLinkWithEmailArgs with the email."""
+        self.email = email
+        self.type = link_type
+        self.send = send
+
 
 class MagicLinkWithPhoneArgs(MagicLinkArgsBase):
     """Arguments for creating a Magic Link with a phone number."""
 
     phone: str
+
+    def __init__(self, *, phone: str, link_type: MagicLinkType, send: bool) -> None:
+        """Initialize the MagicLinkWithPhoneArgs with the phone number."""
+        self.phone = phone
+        self.type = link_type
+        self.send = send
 
 
 class MagicLinkWithUserArgs(MagicLinkArgsBase):
@@ -30,6 +42,13 @@ class MagicLinkWithUserArgs(MagicLinkArgsBase):
 
     user_id: str
     channel: MagicLinkChannel
+
+    def __init__(self, *, user_id: str, channel: MagicLinkChannel, link_type: MagicLinkType, send: bool) -> None:
+        """Initialize the MagicLinkWithUserArgs with the user ID."""
+        self.user_id = user_id
+        self.channel = channel
+        self.type = link_type
+        self.send = send
 
 
 MagicLinkArgs = Union[MagicLinkWithEmailArgs, MagicLinkWithPhoneArgs, MagicLinkWithUserArgs]

--- a/passageidentity/models/magic_link_options.py
+++ b/passageidentity/models/magic_link_options.py
@@ -10,3 +10,17 @@ class MagicLinkOptions:
     magic_link_path: str | None
     redirect_url: str | None
     ttl: int | None
+
+    def __init__(
+        self,
+        *,
+        language: str | None = None,
+        magic_link_path: str | None = None,
+        redirect_url: str | None = None,
+        ttl: int | None = None,
+    ) -> None:
+        """Initialize the options with the given values."""
+        self.language = language
+        self.magic_link_path = magic_link_path
+        self.redirect_url = redirect_url
+        self.ttl = ttl


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

this changes the DX from
```py
args = MagicLinkWithEmailArgs()
args.email = 'email'
args.type = MagicLinkType.LOGIN
args.send = True
ml = passage.auth.create_magic_link(args)
```

to
```py
args = MagicLinkWithEmailArgs(email='email', link_type=MagicLinkType.LOGIN, send=True)
ml = passage.auth.create_magic_link(args)
```

## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
