### PR TITLE
build: pin codegen version

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -10,7 +10,7 @@ rm -rf ./passageidentity/openapi_client
 
 file="$1"
 
-docker run --rm -v "${PWD}:/local" -u $(id -u) openapitools/openapi-generator-cli:latest generate \
+docker run --rm -v "${PWD}:/local" -u $(id -u) openapitools/openapi-generator-cli:v7.10.0 generate \
   -i "/local/$file" \
   -g python \
   -o /local/temp \


### PR DESCRIPTION
### Overview of Changes in this PR

-   pin the openapi-generator image to last used minor version

This ensures more predictable code generation by preventing unintended changes from upstream updates.

Long-term, we could introduce scheduled runs using the [latest-release](https://hub.docker.com/r/openapitools/openapi-generator-cli/tags) tag. For now, keeping the version fixed helps maintain consistency when propagating schema changes.

We can still manually update the version as needed to pull in major fixes or features.